### PR TITLE
Added support for /sha1 command-line (hash of the certificate)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+/.vscode

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,7 @@ module.exports = function(grunt) {
         options: {
           certificateFilePath: '',
           certificatePassword: '',
+          certificateSha1: '',
         },
         files: {
           src: ['']

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
           certificateFilePath: '',
           certificatePassword: '',
           certificateSha1: '',
+          forceXml: false
         },
         files: {
           src: ['']

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ grunt.initConfig({
     options: {
       certificateFilePath: '/path/to/certificate.pfx',
       certificatePassword: 'certificate-password',
+      certificateSha1: '0123456789abcdef0123456789abcdef01234567',
       signToolPath: '/path/to/my/local/sign/tool'
     },
     files: {
@@ -46,13 +47,19 @@ grunt.initConfig({
 Type: `String`
 Default value: null
 
-Defines the file path of the certificate to be used for code signing.
+Defines the file path of the certificate to be used for code signing. If specified, the _certificateSha1_ property will be ignored.
 
 #### options.certificatePassword
 Type: `String`
 Default value: null
 
-Defines the password, if available, of the certificate.
+Defines the password, if available, of the certificate. Requires _certificateFilePath_ to be specified.
+
+#### options.certificateSha1
+Type: `String`
+Default value: null
+
+Defines the SHA1 fingerprint of the certificate to use. The SHA1 hash is commonly specified when multiple certificates installed in the certificate store satisfy the criteria specified by the remaining switches, or if the certificate file is not available.
 
 #### options.signToolPath
 Type: `String`

--- a/cs/xmlsign.cs
+++ b/cs/xmlsign.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography.Xml;
+using System.Xml;
+
+namespace XmlTools
+{
+    static class Messages
+    { 
+        public const string EXC_MissingCert = "Xml file {0} not successfully signed. Please check that one of the required certificates is installed in the system.";
+        public const string EXC_CertLocalMachineRights = "Xml file {0} not successfully signed. Please check that the certificate '{1}' installed as LocalMachine has correct read rights. Inner exception: {2}";
+        public const string EXC_VerifySignature = "Internal error: cannot apply/verify signature to {0}";
+        public const string Msg_SignTry = "Trying to use sha1 {0} with {1}, on {2}."; 
+        public const string Str_CUSign = "CurrentUser";
+        public const string Str_LMSign = "LocalMachine";
+        public const string Msg_KeyFound = "Key found.";
+    }
+
+    class XmlSignatureHelper
+    {
+        private string[] _shaStrings;
+        private bool _verbose;
+
+        public XmlSignatureHelper(string[] shaStrings, bool verbose) 
+        {
+            _shaStrings = shaStrings;
+            _verbose = verbose;
+        }
+
+        private void Verbose(string msg, params string[] args)
+        {
+            if (_verbose) 
+            {
+                Console.WriteLine(msg, args);
+            }
+        }
+
+        private void Warning(string msg, params string[] args)
+        {
+            Console.WriteLine(msg, args);
+        }
+
+        private void Error(string msg, params string[] args)
+        {
+            Console.Error.WriteLine(msg, args);
+        }
+
+        /// <summary>
+        /// Sign the passed XML document using envelope method (signature will be inserted inside the XML)
+        /// </summary>
+        /// <param name="doc">The XML document to sign</param>
+        /// <returns>true if the doc has been signed or however it is still valid file (warning reported)</returns>
+        public bool Sign(XmlDocument doc, string xmlFileName)
+        {
+            if (doc == null || doc.DocumentElement == null)
+            {
+                throw new ArgumentNullException("doc");
+            }
+
+            // Get the certificate which will be used for signign
+            X509Certificate2 certificate = RetrieveCertificate();
+            if (certificate == null)
+            {
+                Warning(Messages.EXC_MissingCert, xmlFileName);
+                // Still valid
+                return true;
+            }
+            AsymmetricAlgorithm key;
+            try
+            {
+                key = certificate.PrivateKey;
+            }
+            catch (CryptographicException exc)
+            {
+                Warning(Messages.EXC_CertLocalMachineRights, xmlFileName, certificate.SubjectName.Decode(X500DistinguishedNameFlags.UseSemicolons), exc.Message);
+                return true;
+            }
+
+            Reference reference = new Reference { Uri = "" };
+            reference.AddTransform(new XmlDsigEnvelopedSignatureTransform());
+
+            SignedXml signedXml = new SignedXml(doc) { SigningKey = key };
+            signedXml.AddReference(reference);
+            
+            signedXml.ComputeSignature();
+
+            if (!VerifySignature(signedXml, certificate))
+            {
+                Error(Messages.EXC_VerifySignature, xmlFileName);
+                return false;
+            }
+
+            XmlElement xmlDigitalSignature = signedXml.GetXml();
+            doc.DocumentElement.AppendChild(doc.ImportNode(xmlDigitalSignature, true));
+
+            return true;
+        }
+
+        /// <summary>
+        /// Verifies the signature contained in the passed signed xml
+        /// </summary>
+        /// <param name="signedXml">The signed xml to verify</param>
+        /// <param name="cert">The certificate to check against</param>
+        /// <returns>true if the signature is verified, false otherwise</returns>
+        private bool VerifySignature(SignedXml signedXml, X509Certificate2 cert)
+        {
+            return signedXml.CheckSignature(cert, true);
+        }
+
+        private X509Certificate2 RetrieveCertificate()
+        {
+            if (_shaStrings.Length > 0)
+            {
+                return TryStore(new X509Store(StoreName.My, StoreLocation.CurrentUser), Messages.Str_CUSign) ?? TryStore(new X509Store(StoreName.My, StoreLocation.LocalMachine), Messages.Str_LMSign);
+            }
+            return null;
+        }
+
+        private X509Certificate2 TryStore(X509Store store, string storeName)
+        {
+            X509Certificate2 retValue = null;
+            store.Open(OpenFlags.ReadOnly);
+            foreach (string sha1 in _shaStrings)
+            {
+                Verbose(Messages.Msg_SignTry, sha1, "X509Store", storeName);
+
+                X509Certificate2Collection certificateCollection = store.Certificates.Find(X509FindType.FindByThumbprint, sha1, true);
+                if (certificateCollection.Count >= 1)
+                {
+                    retValue = certificateCollection[0];
+                    Verbose(Messages.Msg_KeyFound);
+                    break;
+                }
+            }
+            store.Close();
+            return retValue;
+        }
+    }
+
+    static class Program
+    {
+        private static void ShowHelp()
+        {
+            Console.WriteLine("Usage: xmlsign /in <infile> [/out <outfile>] /sha1 <sha1> [/sha1 <sha1b> ...]");
+        }
+
+        /// <summary>
+        /// Take the source XML, the target XML (it can be the same), and the set of the sha1 keys to use 
+        /// </summary>
+        public static int Main(params string[] args)
+        {
+            string inputFile = null;
+            string outputFile = null;
+            List<string> sha1 = new List<string>();
+            for (int i = 0; i < args.Length - 1; i++) 
+            {
+                switch (args[i]) 
+                {
+                    case "/in":
+                        inputFile = args[++i];
+                        break;
+                    case "/out":
+                        outputFile = args[++i];
+                        break;
+                    case "/sha1":
+                        sha1.Add(args[++i]);
+                        break;
+                }
+            }
+
+            if (inputFile == null)
+            {
+                Console.Error.WriteLine("Missing input file");
+                ShowHelp();
+                return 1;
+            }
+            if (outputFile == null)
+            {
+                outputFile = inputFile;
+            }
+            if (sha1.Count == 0)
+            {
+                Console.Error.WriteLine("Missing SHA1 parameter");
+                ShowHelp();
+                return 1;
+            }
+
+            var helper = new XmlSignatureHelper(sha1.ToArray(), true); 
+            var doc = new XmlDocument();
+            doc.Load(inputFile);
+            if (helper.Sign(doc, inputFile))
+            {
+                doc.Save(outputFile);
+                return 0;
+            }
+            else 
+            {
+                return 1;
+            }
+        }
+    }
+}

--- a/cs/xmlsign.cs
+++ b/cs/xmlsign.cs
@@ -143,7 +143,7 @@ namespace XmlTools
     {
         private static void ShowHelp()
         {
-            Console.WriteLine("Usage: xmlsign /in <infile> [/out <outfile>] /sha1 <sha1> [/sha1 <sha1b> ...]");
+            Console.WriteLine("Usage: xmlsign <infile> [/v | /verbose] [/o | /out <outfile>] /sha1 <sha1> [/sha1 <sha1b> ...]");
         }
 
         /// <summary>
@@ -153,19 +153,39 @@ namespace XmlTools
         {
             string inputFile = null;
             string outputFile = null;
+            bool verbose = false;
             List<string> sha1 = new List<string>();
-            for (int i = 0; i < args.Length - 1; i++) 
+            for (int i = 0; i < args.Length; i++) 
             {
+                if (args[i][0] != '/') 
+                {
+                    if (inputFile != null)
+                    {
+                        Console.Error.WriteLine("Multiple input files not supported");
+                        return 1;
+                    }
+                    inputFile = args[i];
+                    continue;
+                }
+
                 switch (args[i]) 
                 {
-                    case "/in":
-                        inputFile = args[++i];
+                    case "/v":
+                    case "/verbose":
+                        verbose = true;
                         break;
+                    case "/o":
                     case "/out":
-                        outputFile = args[++i];
+                        if (i < args.Length - 1) 
+                        {
+                            outputFile = args[++i];
+                        }
                         break;
                     case "/sha1":
-                        sha1.Add(args[++i]);
+                        if (i < args.Length - 1) 
+                        {
+                            sha1.Add(args[++i]);
+                        }
                         break;
                 }
             }
@@ -187,7 +207,7 @@ namespace XmlTools
                 return 1;
             }
 
-            var helper = new XmlSignatureHelper(sha1.ToArray(), true); 
+            var helper = new XmlSignatureHelper(sha1.ToArray(), verbose); 
             var doc = new XmlDocument();
             doc.Load(inputFile);
             if (helper.Sign(doc, inputFile))

--- a/tasks/codesign.js
+++ b/tasks/codesign.js
@@ -47,14 +47,21 @@ module.exports = function(grunt) {
 
 
         args = ['sign'];
-        // signing cert file path
-        args.push('/f', options.certificateFilePath);
+
+        // sign with cert file path?
+        if (options.certificateFilePath) {
+          args.push('/f', options.certificateFilePath);
+          // certificate password
+          if (options.certificatePassword) {
+            args.push('/p', options.certificatePassword);
+          }
+        }
+        else if (options.certificateSha1) {
+          // Use SHA1 thumbprint (the cert should be installed in the store)
+          args.push('/sha1', options.certificateSha1);
+        }
         // verbose
         args.push('/v');
-        // certificate password
-        if (options.certificatePassword) {
-          args.push('/p', options.certificatePassword);
-        }
         break;
       default:
         grunt.fail.fatal('Unsupported platform: ' + process.platform);

--- a/tasks/codesign.js
+++ b/tasks/codesign.js
@@ -79,15 +79,15 @@ module.exports = function(grunt) {
       grunt.util.spawn({
         cmd: 'csc',
         args: ['xmlsign.cs'],
-        opts: { cwd: './cs' }
+        opts: { cwd: path.join(__dirname, '../cs') }
       }, function(error, result, code) {
           if (code !== 0) {
-            grunt.verbose.writeln(result);
-            grunt.fail.warn(error);
+            grunt.verbose.writeln((result && result.stdout) || result);
+            grunt.fail.warn((result && result.stderr) || error);
             xmlsign = { };
           }
           else {
-            xmlsign = { cmd: './cs/xmlsign', args: ['/v', '/sha1', options.certificateSha1] };
+            xmlsign = { cmd:  path.join(__dirname, '../cs/xmlsign'), args: ['/v', '/sha1', options.certificateSha1] };
           }
           callback(xmlsign.cmd, xmlsign.args);
       });
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
 
     this.filesSrc.forEach(function(file) {
       var ext = path.extname(file);
-      if (ext !== '.xml' && !forceXml) {
+      if (ext !== '.xml' && !options.forceXml) {
         grunt.log.ok("signing " + file + " with signtool");
         grunt.util.spawn({
           cmd: cmd,

--- a/tasks/codesign.js
+++ b/tasks/codesign.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
 
     this.filesSrc.forEach(function(file) {
       var ext = path.extname(file);
-      if (ext !== '.xml') {
+      if (ext !== '.xml' && !forceXml) {
         grunt.log.ok("signing " + file + " with signtool");
         grunt.util.spawn({
           cmd: cmd,


### PR DESCRIPTION
Hi,
I've added the support for the /sha1 command line, that is very useful to address a certificate already in the certificate store addressed by its firgerprint (no need to have the private key around in a file).
Thanks!
 Luciano
